### PR TITLE
Improve LOD tree and allow user to input tileset URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ dist-ssr
 
 data/*
 !data/SanFran_Street_level_Ferry_building
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+data/*
+!data/SanFran_Street_level_Ferry_building

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,7 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
 
 export default [
   { ignores: ['dist'] },
@@ -28,6 +28,9 @@ export default [
         'warn',
         { allowConstantExport: true },
       ],
+      quotes: ['error', 'single'],
+      indent: ['error', 2],
+      semi: ['error'],
     },
   },
-]
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "3dtiles-webviewer",
       "version": "0.0.0",
       "dependencies": {
+        "@itwin/itwinui-icons-color-react": "^2.1.0",
         "@itwin/itwinui-react": "^5.0.0-alpha.11",
         "cesium": "^1.127.0",
         "react": "^19.0.0",
@@ -1043,6 +1044,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@itwin/itwinui-icons-color-react": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@itwin/itwinui-icons-color-react/-/itwinui-icons-color-react-2.1.0.tgz",
+      "integrity": "sha512-Rv/ELthIpKzQaHnrlwNbaGp/yWF8vBIxDBXc+I1TSuDf4w2MC6YI0333XJK2emNDQRAcbw7qpxW4cG0o5ELxDA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.6",
+        "react-dom": ">=16.8.6"
       }
     },
     "node_modules/@itwin/itwinui-react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,11 @@
         "vite-plugin-static-copy": "^2.3.0"
       },
       "devDependencies": {
-        "@eslint/js": "^9.21.0",
+        "@eslint/js": "^9.25.1",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
         "@vitejs/plugin-react": "^4.3.4",
-        "eslint": "^9.21.0",
+        "eslint": "^9.25.1",
         "eslint-plugin-react-hooks": "^5.1.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^15.15.0",
@@ -847,9 +847,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
-      "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
+      "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -862,9 +862,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.0.tgz",
-      "integrity": "sha512-yJLLmLexii32mGrhW29qvU3QBVTu0GUmEf/J4XsBtVhp4JkIUFN/BjWqTF63yRvGApIDpZm5fa97LtYtINmfeQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.2.tgz",
+      "integrity": "sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -872,9 +872,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
-      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
+      "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -922,9 +922,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.23.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.23.0.tgz",
-      "integrity": "sha512-35MJ8vCPU0ZMxo7zfev2pypqTwWTofFZO6m4KAtdoFhRpLJUpHTZZ+KB3C7Hb1d7bULYwO4lJXGCi5Se+8OMbw==",
+      "version": "9.25.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.25.1.tgz",
+      "integrity": "sha512-dEIwmjntEx8u3Uvv+kr3PDeeArL8Hw07H9kyYxCjnM9pBjfEhk6uLXSchxxzgiwtRhhzVzqmUSDFBOi1TuZ7qg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -942,13 +942,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
-      "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
+      "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.12.0",
+        "@eslint/core": "^0.13.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -2066,20 +2066,20 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.23.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.23.0.tgz",
-      "integrity": "sha512-jV7AbNoFPAY1EkFYpLq5bslU9NLNO8xnEeQXwErNibVryjk67wHVmddTBilc5srIttJDBrB0eMHKZBFbSIABCw==",
+      "version": "9.25.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.25.1.tgz",
+      "integrity": "sha512-E6Mtz9oGQWDCpV12319d59n4tx9zOTXSTmc8BLVxBx+G/0RdM5MvEEJLU9c0+aleoePYYgVTOsRblx433qmhWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.2",
-        "@eslint/config-helpers": "^0.2.0",
-        "@eslint/core": "^0.12.0",
+        "@eslint/config-array": "^0.20.0",
+        "@eslint/config-helpers": "^0.2.1",
+        "@eslint/core": "^0.13.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.23.0",
-        "@eslint/plugin-kit": "^0.2.7",
+        "@eslint/js": "9.25.1",
+        "@eslint/plugin-kit": "^0.2.8",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@itwin/itwinui-icons-color-react": "^2.1.0",
     "@itwin/itwinui-react": "^5.0.0-alpha.11",
     "cesium": "^1.127.0",
     "react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "vite-plugin-static-copy": "^2.3.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.21.0",
+    "@eslint/js": "^9.25.1",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react": "^4.3.4",
-    "eslint": "^9.21.0",
+    "eslint": "^9.25.1",
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^15.15.0",

--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,3 @@
-
 body {
   background: #000;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,17 +1,16 @@
-import Outer from './components/outer'
-import './App.css'
-import "cesium/Build/Cesium/Widgets/widgets.css";
+import Outer from './components/outer';
+import './App.css';
+import 'cesium/Build/Cesium/Widgets/widgets.css';
 import { Root } from '@itwin/itwinui-react/bricks';
 
 function App() {
-
   return (
     <>
       <Root colorScheme='dark' density='medium'>
         <Outer/>
       </Root>
     </>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/components/CesiumMap.jsx
+++ b/src/components/CesiumMap.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
-import { Viewer as CesiumViewer, Terrain, Ion } from "cesium";
+import { Viewer as CesiumViewer, Ion } from 'cesium';
 
-const CESIUM_CONTAINER_ID = "cesiumContainer";
+const CESIUM_CONTAINER_ID = 'cesiumContainer';
 
 const CesiumMap = ({ cesiumViewer, setCesiumViewer }) => {
   const viewerContainer = useRef(null);
@@ -14,10 +14,9 @@ const CesiumMap = ({ cesiumViewer, setCesiumViewer }) => {
 
       const viewer = new CesiumViewer(
         CESIUM_CONTAINER_ID,
-        // { terrain: Terrain.fromWorldTerrain() }
       );
       setCesiumViewer(viewer);
-    }
+    };
     if (!cesiumViewer) {
       initializeGlobe();
     }

--- a/src/components/CesiumMap.jsx
+++ b/src/components/CesiumMap.jsx
@@ -1,20 +1,25 @@
 import React, { useEffect, useRef } from 'react';
-import { Viewer as CesiumViewer, Entity, TerrainProvider } from "cesium";
+import { Viewer as CesiumViewer, Terrain, Ion } from "cesium";
 
 const CESIUM_CONTAINER_ID = "cesiumContainer";
 
 const CesiumMap = ({ cesiumViewer, setCesiumViewer }) => {
   const viewerContainer = useRef(null);
-  //const [cesiumViewer, setCesiumViewer] = useState();
 
   useEffect(() => {
-
     const initializeGlobe = () => {
-      const viewer = new CesiumViewer(CESIUM_CONTAINER_ID);
-      setCesiumViewer(viewer) 
+      const ionToken = import.meta.env.VITE_ION_TOKEN;
+      if (ionToken)
+        Ion.defaultAccessToken = ionToken;
+
+      const viewer = new CesiumViewer(
+        CESIUM_CONTAINER_ID,
+        { terrain: Terrain.fromWorldTerrain() }
+      );
+      setCesiumViewer(viewer);
     }
-    if (!cesiumViewer ) {
-      initializeGlobe()
+    if (!cesiumViewer) {
+      initializeGlobe();
     }
   }, [cesiumViewer, setCesiumViewer]);
 

--- a/src/components/CesiumMap.jsx
+++ b/src/components/CesiumMap.jsx
@@ -14,7 +14,7 @@ const CesiumMap = ({ cesiumViewer, setCesiumViewer }) => {
 
       const viewer = new CesiumViewer(
         CESIUM_CONTAINER_ID,
-        { terrain: Terrain.fromWorldTerrain() }
+        // { terrain: Terrain.fromWorldTerrain() }
       );
       setCesiumViewer(viewer);
     }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,24 +1,23 @@
-import React from "react";
+import React from 'react';
 import { Button } from '@itwin/itwinui-react/bricks';
 
 let Header = () => {
-    const handleClick = () => {
-    }
-    return (
-        <>
-            <div className="header">
-                <div className="header-logo-container">
-                    {"Logo"}
-                </div>
-                <div className="header-title-container">
-                    {"Header"}
-                </div>
-                <div className="header-button-container">
-                        <Button onClick={handleClick}> Login</Button>
-                </div>
-            </div>
-        </>
-    );
-}
+  const handleClick = () => {};
+  return (
+    <>
+      <div className='header'>
+        <div className='header-logo-container'>
+          {'Logo'}
+        </div>
+        <div className='header-title-container'>
+          {'Header'}
+        </div>
+        <div className='header-button-container'>
+          <Button onClick={handleClick}> Login</Button>
+        </div>
+      </div>
+    </>
+  );
+};
 
 export default Header;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,30 +4,12 @@ import { parseTileset, LevelOfDetail } from '../tilesetParser';
 
 const tilesetPath = './cesiumStatic/data/SanFran_Street_level_Ferry_building/tileset.json';
 const tilesetData = await parseTileset(tilesetPath, []);
+for (let i = 0; i < tilesetData.length; i++) {
+  if (!tilesetData[i]) {
+    tilesetData[i] = { tiles: [], expanded: false, selected: false, level: i };
+  }
+}
 // console.log(tilesetData);
-
-const testData = [
-  {
-    id: 'Node-0',
-    label: 'Node 0',
-    selected: false,
-    expanded: true,
-  },
-  {
-    id: 'Node-1',
-    label: 'Node 1',
-    selected: false,
-    expanded: true,
-    subItems: [{ id: 'Subnode-1', label: 'Subnode 1', selected: false }],
-  },
-  {
-    id: 'Node-2',
-    label: 'Node 2',
-    selected: false,
-    expanded: true,
-    subItems: [{ id: 'Subnode-2', label: 'Subnode 2', selected: false }],
-  },
-];
 
 let Sidebar = () => {
   const [data, setData] = React.useState(tilesetData);
@@ -37,16 +19,17 @@ let Sidebar = () => {
     <Tree.Root>
       {data.map((item, index, items) => {
         const handleSelection = () => {
+          item
           console.log('handleSelection');
         }
         
         const handleExpanded = () => {
           console.log('handleExpanded');
-          // const oldExpanded = data[index].expanded;
-          // if (oldExpanded === undefined) return;
-          // const newData = [...data];
-          // newData[index].expanded = !oldExpanded;
-          // setData(newData);
+          const oldExpanded = data[index].expanded;
+          if (oldExpanded === undefined) return;
+          const newData = [...data];
+          newData[index].expanded = !oldExpanded;
+          setData(newData);
         }
 
         return (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,282 +1,329 @@
 import { Matrix4, Model, Math as CesiumMath, HeadingPitchRange, ITwinPlatform, Cesium3DTileset, ITwinData, Matrix3, Cesium3DTile, TileAvailability, Transforms } from 'cesium';
 import React, { useEffect } from 'react';
-import { Tooltip, Tree } from '@itwin/itwinui-react/bricks';
+import { Tooltip, Tree, Button, Label, TextBox } from '@itwin/itwinui-react/bricks';
 import { parseTileset, LevelOfDetail } from '../tilesetParser';
 
-const tilesetPath = 'cesiumStatic/data/SanFran_Street_level_Ferry_building/tileset.json';
+// const tilesetPath = './cesiumStatic/data/SanFran_Street_level_Ferry_building/tileset.json';
 // const tilesetPath = './cesiumStatic/data/Metrostation.bim-tiles/tileset.json';
 // const tilesetPath = './cesiumStatic/data/Stadium-28334163.bim-tiles/tileset.json';
-
 // const tilesetPath = './cesiumStatic/data/04_Plant_Geo.bim-tiles/tileset.json';
 // const tilesetPath = './cesiumStatic/data/ClubHouse.bim-tiles/tileset.json';
 
-let tilesetLoaded = false;
-let globalTransform;
-
-const tilesetData: LevelOfDetail[] = await parseTileset(tilesetPath, [], [], 0);
-console.log("lods:", tilesetData);
-
 let Sidebar = (cesiumViewer) => {
-  const [data, setData] = React.useState<LevelOfDetail[]>(tilesetData);
-  // Format is [lod index, tile index]
+  const [data, setData] = React.useState<LevelOfDetail[]>([]);
+  // Format for selectedLodIndices is [lod index, tile index]
   // If tile index is -1, it means no tile was selected, just entire LOD
   const [selectedLodIndices, setSelectedLodIndices] = React.useState<number[] | undefined>();
+  const [tilesetUrl, setTilesetUrl] = React.useState<string | undefined>();
+  const [tilesetTransform, setTilesetTransform] = React.useState<Matrix4 | undefined>();
 
-  useEffect(() => {
-    (async function() {
-      const { viewer } = cesiumViewer;
-      if (!viewer?.scene) {
-        return;
-      }
+  // useEffect(() => {
+  //   (async function() {
+  //     const { viewer } = cesiumViewer;
+  //     if (!viewer?.scene) {
+  //       return;
+  //     }
 
-      const lods: LevelOfDetail[] = [];
-      const tileset = await Cesium3DTileset.fromUrl(tilesetPath);
+  //     const lods: LevelOfDetail[] = [];
+  //     const tileset = await Cesium3DTileset.fromUrl(tilesetPath);
 
-      // ITwinPlatform.apiEndpoint = "https://qa-ims.bentley.com/";
-      // ITwinPlatform.defaultAccessToken = "";
-      // const tileset = await ITwinData.createTilesetFromIModelId(
-      //   "",
-      // );
+  //     // ITwinPlatform.apiEndpoint = "https://qa-ims.bentley.com/";
+  //     // ITwinPlatform.defaultAccessToken = "";
+  //     // const tileset = await ITwinData.createTilesetFromIModelId(
+  //     //   "",
+  //     // );
 
-      if (!tileset) {
-        return;
-      }
+  //     if (!tileset) {
+  //       return;
+  //     }
 
-      // tileset.skipLevelOfDetail = false;
-      // tileset.maximumScreenSpaceError = 0;
-      // tileset.preloadWhenHidden = true;
-      // tileset.show = false;
-      // tileset.maximumCacheOverflowBytes = 536870912 * 10;
+  //     // tileset.skipLevelOfDetail = false;
+  //     // tileset.maximumScreenSpaceError = 0;
+  //     // tileset.preloadWhenHidden = true;
+  //     // tileset.show = false;
+  //     // tileset.maximumCacheOverflowBytes = 536870912 * 10;
 
-      // Combine the transforms
-      const rotationMatrix = Matrix3.fromRotationZ(CesiumMath.toRadians(-90));
-      const rotationMatrix4x4 = Matrix4.fromRotationTranslation(rotationMatrix);
-      globalTransform = Matrix4.multiply(tileset.root.transform, rotationMatrix4x4, new Matrix4());
+  //     // Combine the transforms
+  //     const rotationMatrix = Matrix3.fromRotationZ(CesiumMath.toRadians(-90));
+  //     const rotationMatrix4x4 = Matrix4.fromRotationTranslation(rotationMatrix);
+  //     globalTransform = Matrix4.multiply(tileset.root.transform, rotationMatrix4x4, new Matrix4());
 
-      // viewer.scene.primitives.add(tileset);
-      // viewer.zoomTo(tileset);
+  //     // viewer.scene.primitives.add(tileset);
+  //     // viewer.zoomTo(tileset);
 
-      function trackTile(tile: any) {
-        const level = parseInt(tile._depth);
-        const index = level - 1;
-        // Get just tile name, without full URL and query string
-        const displayName = tile.content.url.split('/').pop().split('?')[0];
-        const tileData = {
-          displayName: displayName,
-          uri: tile.content.url,
-          selected: false,
-          geometricError: tile.geometricError,
-        };
+  //     function trackTile(tile: any) {
+  //       const level = parseInt(tile._depth);
+  //       const index = level - 1;
+  //       // Get just tile name, without full URL and query string
+  //       const displayName = tile.content.url.split('/').pop().split('?')[0];
+  //       const tileData = {
+  //         displayName: displayName,
+  //         uri: tile.content.url,
+  //         selected: false,
+  //         geometricError: tile.geometricError,
+  //       };
 
-        if (lods[index]) {
-          lods[index].tiles.push(tileData);
-        } else {
-          lods[index] = {
-            level: level,
-            expanded: false,
-            selected: false,
-            tiles: [ tileData ],
-          };
-        }
-      }
-      // tileset.tileLoad.addEventListener(trackTile);
+  //       if (lods[index]) {
+  //         lods[index].tiles.push(tileData);
+  //       } else {
+  //         lods[index] = {
+  //           level: level,
+  //           expanded: false,
+  //           selected: false,
+  //           tiles: [ tileData ],
+  //         };
+  //       }
+  //     }
+  //     // tileset.tileLoad.addEventListener(trackTile);
 
-      // tileset.allTilesLoaded.addEventListener(() => {
-      //   if (!tilesetLoaded) {
-      //     tileset.tileLoad.removeEventListener(trackTile);
-      //     console.log("all tiles loaded. lods from event listening:", lods);
-      //     // setData(lods);
-      //     tilesetLoaded = true;
-      //   }
+  //     // tileset.allTilesLoaded.addEventListener(() => {
+  //     //   if (!tilesetLoaded) {
+  //     //     tileset.tileLoad.removeEventListener(trackTile);
+  //     //     console.log("all tiles loaded. lods from event listening:", lods);
+  //     //     // setData(lods);
+  //     //     tilesetLoaded = true;
+  //     //   }
 
-      // //   // Weird issue where the tiles recorded with trackTile are not the same as
-      // //   // the tiles parsed in tilesetData - trackTile is missing some
+  //     // //   // Weird issue where the tiles recorded with trackTile are not the same as
+  //     // //   // the tiles parsed in tilesetData - trackTile is missing some
 
-      // //   // console.log("comparing with parsed data...");
-      // //   // for (let i = 1; i < lods.length; i++) {
-      // //   //   if (lods[i + 2] && lods[i + 2].tiles.length !== tilesetData[i].tiles.length) {
-      // //   //     console.log("parsed tileset data and event tileset data do not match at level", i);
+  //     // //   // console.log("comparing with parsed data...");
+  //     // //   // for (let i = 1; i < lods.length; i++) {
+  //     // //   //   if (lods[i + 2] && lods[i + 2].tiles.length !== tilesetData[i].tiles.length) {
+  //     // //   //     console.log("parsed tileset data and event tileset data do not match at level", i);
 
-      // //   //     if (i < 4) {
-      // //   //       for (let j = 0; j < tilesetData[i].tiles.length; j++) {
-      // //   //         const tile = tilesetData[i].tiles[j];
-      // //   //         const found = lods[i + 2].tiles.find((t) => {
-      // //   //           const tileUri = t.uri.split('/').slice(-2).join('/');
-      // //   //           return tileUri === tile.uri;
-      // //   //         });
-      // //   //         if (!found) {
-      // //   //           console.log("missing tile", tile.uri, "at level", i);
-      // //   //         }
-      // //   //       }
-      // //   //     }
-      // //   //   }
-      // //   // }
+  //     // //   //     if (i < 4) {
+  //     // //   //       for (let j = 0; j < tilesetData[i].tiles.length; j++) {
+  //     // //   //         const tile = tilesetData[i].tiles[j];
+  //     // //   //         const found = lods[i + 2].tiles.find((t) => {
+  //     // //   //           const tileUri = t.uri.split('/').slice(-2).join('/');
+  //     // //   //           return tileUri === tile.uri;
+  //     // //   //         });
+  //     // //   //         if (!found) {
+  //     // //   //           console.log("missing tile", tile.uri, "at level", i);
+  //     // //   //         }
+  //     // //   //       }
+  //     // //   //     }
+  //     // //   //   }
+  //     // //   // }
 
-      // });
-    })()
-  }, [cesiumViewer]);
+  //     // });
+  //   })()
+  // }, [cesiumViewer]);
 
   return (
     <div className='sidebar'>
-    <Tree.Root className='lod-tree' style={{ backgroundColor: 'var(--ids-color-bg-neutral-base)' }}>
-      {data.map((item, index, items) => {
-        const handleSelection = async () => {
-          console.log("handleSelection", item);
-          
-          if (!item.expanded) {
-            handleExpanded();
-          }
+      <div style={{ display: 'flex', gap: 6, alignItems: 'center', padding: '12px' }}>
+        <Label>Tileset URL</Label>
+        <TextBox.Root>
+          <TextBox.Input id={'tilesetUrlInput'} />
+        </TextBox.Root>
+        <Button
+					onClick={async (e) => {
+            console.log('load tileset button clicked');
+            const url = (document.getElementById('tilesetUrlInput') as HTMLInputElement).value;
+            if (!url) {
+              console.log('no url provided');
+              return;
+            }
+            console.log('loading from url', url);
 
-          if (!item.selected) {
-            const newData = [...data];
+            let absoluteUrl: string;
+            if (url.indexOf("://") > 0 || url.indexOf("//") === 0) {
+              absoluteUrl = url;
+            } else {
+              absoluteUrl = new URL(url, window.location.href).href;
+            }
 
-             // Reset previous selection
-            if (selectedLodIndices) {
-              const lodIndex = selectedLodIndices[0];
-              newData[lodIndex].selected = false;
-              const tileIndex = selectedLodIndices[1];
-              if (tileIndex !== -1) {
-                newData[lodIndex].tiles[tileIndex].selected = false;
+            // No need to reload tileset if URL is the same
+            if (absoluteUrl === tilesetUrl) {
+              console.log("url is the same, not reloading tileset");
+              return;
+            }
+            setTilesetUrl(absoluteUrl);
+
+            let tilesetData: LevelOfDetail[] = [];
+            if (absoluteUrl) {
+              try {
+                tilesetData = await parseTileset(absoluteUrl, [], [], 0);
+              } catch (error) {
+                console.error("Error parsing tileset:", error);
+                return;
+              }
+              
+              setData(tilesetData);
+            }
+            console.log("lods:", tilesetData);
+
+            // Load tileset to get transform
+            const { viewer } = cesiumViewer;
+            const tileset = await Cesium3DTileset.fromUrl(absoluteUrl);
+            viewer.zoomTo(tileset);
+
+            const rotationMatrix = Matrix3.fromRotationZ(CesiumMath.toRadians(-90));
+            const rotationMatrix4x4 = Matrix4.fromRotationTranslation(rotationMatrix);
+            const transform = Matrix4.multiply(tileset.root.transform, rotationMatrix4x4, new Matrix4());
+            setTilesetTransform(transform);
+					}}
+				>
+					Load
+				</Button>
+      </div>
+      <Tree.Root className='lod-tree' style={{ backgroundColor: 'var(--ids-color-bg-neutral-base)' }}>
+        {data.map((item, index, items) => {
+          const handleSelection = async () => {
+            console.log("handleSelection", item);
+            
+            if (!item.expanded) {
+              handleExpanded();
+            }
+
+            if (!item.selected) {
+              const newData = [...data];
+
+              // Reset previous selection
+              if (selectedLodIndices) {
+                const lodIndex = selectedLodIndices[0];
+                newData[lodIndex].selected = false;
+                const tileIndex = selectedLodIndices[1];
+                if (tileIndex !== -1) {
+                  newData[lodIndex].tiles[tileIndex].selected = false;
+                }
+              }
+              setSelectedLodIndices([index, -1]);
+
+              newData[index].selected = true;
+              setData(newData);
+            }
+
+            const { viewer } = cesiumViewer;
+            // Clear previous models
+            viewer.scene.primitives.removeAll();
+
+            let model;
+            for (const tile of item.tiles) {
+              try {
+                model = viewer.scene.primitives.add(
+                  await Model.fromGltfAsync({
+                    url: tile.uri,
+                    modelMatrix: tilesetTransform,
+                  }),
+                );
+              } catch (error) {
+                console.log("error", error);
               }
             }
-            setSelectedLodIndices([index, -1]);
 
-            newData[index].selected = true;
+            model.readyEvent.addEventListener(() => {
+              const camera = viewer.camera;
+
+              // Zoom to model
+              const controller = viewer.scene.screenSpaceCameraController;
+              const r = 2.0 * Math.max(model.boundingSphere.radius, camera.frustum.near);
+              controller.minimumZoomDistance = r * 0.5;
+
+              const center = model.boundingSphere.center;
+              const heading = CesiumMath.toRadians(230.0);
+              const pitch = CesiumMath.toRadians(-20.0);
+              camera.lookAt(center, new HeadingPitchRange(heading, pitch, r * 7.0));
+            })
+          };
+          
+          const handleExpanded = () => {
+            console.log('handleExpanded');
+            const oldExpanded = data[index].expanded;
+            if (oldExpanded === undefined) return;
+            const newData = [...data];
+            newData[index].expanded = !oldExpanded;
             setData(newData);
           }
 
-          const { viewer } = cesiumViewer;
-          // Clear previous models
-          viewer.scene.primitives.removeAll();
+          return (
+            <React.Fragment key={item.level}>
+              <Tree.Item
+                key={item.level}
+                aria-level={1}
+                aria-posinset={index + 1}
+                aria-setsize={items.length}
+                // Should this label be the tree depth (level) or the index?
+                // Index is geneerally same as depth, after empty levels are removed
+                label={index}
+                selected={item.selected}
+                expanded={item.expanded}
+                onSelectedChange={handleSelection}
+                onExpandedChange={handleExpanded}
+              />
+              {item.tiles.map((child, childIndex, children) => {
+                if (!item.expanded) return null;
 
-          let model;
-          for (const tile of item.tiles) {
-            try {
-              model = viewer.scene.primitives.add(
-                await Model.fromGltfAsync({
-                  url: tile.uri,
-                  modelMatrix: globalTransform,
-                }),
-              );
-            } catch (error) {
-              console.log("error", error);
-            }
-          }
+                const handleSelection = async () => {
+                  console.log('handleSelection', child);
 
-          model.readyEvent.addEventListener(() => {
-            const camera = viewer.camera;
+                  if (!child.selected || (item.selected && child.selected)) {
+                    const newData = [...data];
 
-            // Zoom to model
-            const controller = viewer.scene.screenSpaceCameraController;
-            const r = 2.0 * Math.max(model.boundingSphere.radius, camera.frustum.near);
-            controller.minimumZoomDistance = r * 0.5;
-
-            const center = model.boundingSphere.center;
-            const heading = CesiumMath.toRadians(230.0);
-            const pitch = CesiumMath.toRadians(-20.0);
-            camera.lookAt(center, new HeadingPitchRange(heading, pitch, r * 7.0));
-
-            // viewer.zoomTo(model);
-          })
-        };
-        
-        const handleExpanded = () => {
-          console.log('handleExpanded');
-          const oldExpanded = data[index].expanded;
-          if (oldExpanded === undefined) return;
-          const newData = [...data];
-          newData[index].expanded = !oldExpanded;
-          setData(newData);
-        }
-
-        return (
-          <React.Fragment key={item.level}>
-            <Tree.Item
-              key={item.level}
-              aria-level={1}
-              aria-posinset={index + 1}
-              aria-setsize={items.length}
-              // Should this label be the tree depth (level) or the index?
-              // Index is geneerally same as depth, after empty levels are removed
-              label={index}
-              selected={item.selected}
-              expanded={item.expanded}
-              onSelectedChange={handleSelection}
-              onExpandedChange={handleExpanded}
-            />
-            {item.tiles.map((child, childIndex, children) => {
-              if (!item.expanded) return null;
-
-              const handleSelection = async () => {
-                console.log('handleSelection', child);
-
-                if (!child.selected || (item.selected && child.selected)) {
-                  const newData = [...data];
-
-                  // Reset previous selection
-                  if (selectedLodIndices) {
-                    const lodIndex = selectedLodIndices[0];
-                    newData[lodIndex].selected = false;
-                    const tileIndex = selectedLodIndices[1];
-                    if (tileIndex !== -1) {
-                      newData[lodIndex].tiles[tileIndex].selected = false;
+                    // Reset previous selection
+                    if (selectedLodIndices) {
+                      const lodIndex = selectedLodIndices[0];
+                      newData[lodIndex].selected = false;
+                      const tileIndex = selectedLodIndices[1];
+                      if (tileIndex !== -1) {
+                        newData[lodIndex].tiles[tileIndex].selected = false;
+                      }
                     }
+                    setSelectedLodIndices([index, childIndex]);
+
+                    newData[index].tiles[childIndex].selected = true;
+                    setData(newData);
                   }
-                  setSelectedLodIndices([index, childIndex]);
 
-                  newData[index].tiles[childIndex].selected = true;
-                  setData(newData);
-                }
+                  const { viewer } = cesiumViewer;
+                  // Clear previous models
+                  viewer.scene.primitives.removeAll();
 
-                const { viewer } = cesiumViewer;
-                // Clear previous models
-                viewer.scene.primitives.removeAll();
+                  try {
+                    const model = viewer.scene.primitives.add(
+                      await Model.fromGltfAsync({
+                        url: child.uri,
+                        modelMatrix: tilesetTransform,
+                      }),
+                    );
+                    model.readyEvent.addEventListener(() => {
+                      const camera = viewer.camera;
 
-                try {
-                  const model = viewer.scene.primitives.add(
-                    await Model.fromGltfAsync({
-                      url: child.uri,
-                      modelMatrix: globalTransform,
-                    }),
-                  );
-                  model.readyEvent.addEventListener(() => {
-                    const camera = viewer.camera;
+                      // Zoom to model
+                      const controller = viewer.scene.screenSpaceCameraController;
+                      const r = 2.0 * Math.max(model.boundingSphere.radius, camera.frustum.near);
+                      controller.minimumZoomDistance = r * 0.5;
 
-                    // Zoom to model
-                    const controller = viewer.scene.screenSpaceCameraController;
-                    const r = 2.0 * Math.max(model.boundingSphere.radius, camera.frustum.near);
-                    controller.minimumZoomDistance = r * 0.5;
+                      const center = model.boundingSphere.center;
+                      const heading = CesiumMath.toRadians(230.0);
+                      const pitch = CesiumMath.toRadians(-20.0);
+                      camera.lookAt(center, new HeadingPitchRange(heading, pitch, r * 7.0));
+                    })
+                  } catch (error) {
+                    console.log("error", error)
+                  }
+                };
 
-                    const center = model.boundingSphere.center;
-                    const heading = CesiumMath.toRadians(230.0);
-                    const pitch = CesiumMath.toRadians(-20.0);
-                    camera.lookAt(center, new HeadingPitchRange(heading, pitch, r * 7.0));
+                const tooltipContent = `Filename: ${child.uri}\nGeometric error: ${child.geometricError}`;
 
-                    // viewer.zoomTo(model);
-                  })
-                } catch (error) {
-                  console.log("error", error)
-                }
-              };
-
-              const tooltipContent = `Filename: ${child.uri}\nGeometric error: ${child.geometricError}`;
-
-              return <Tooltip content={tooltipContent} style={{ wordBreak: "break-word", maxWidth: "500px", whiteSpace: "pre-wrap" }} key={child.uri}>
-                  <Tree.Item
-                    key={child.uri}
-                    aria-level={2}
-                    aria-posinset={childIndex + 1}
-                    aria-setsize={children.length}
-                    label={child.displayName}
-                    selected={child.selected}
-                    onSelectedChange={handleSelection}
-                  />
-                </Tooltip>
-            })}
-          </React.Fragment>
-        );
-      })}
-    </Tree.Root>
+                return <Tooltip content={tooltipContent} style={{ wordBreak: "break-word", maxWidth: "500px", whiteSpace: "pre-wrap" }} key={child.uri}>
+                    <Tree.Item
+                      key={child.uri}
+                      aria-level={2}
+                      aria-posinset={childIndex + 1}
+                      aria-setsize={children.length}
+                      label={child.displayName}
+                      selected={child.selected}
+                      onSelectedChange={handleSelection}
+                    />
+                  </Tooltip>
+              })}
+            </React.Fragment>
+          );
+        })}
+      </Tree.Root>
     </div>
   )
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,23 +1,20 @@
+import { Matrix4, Model, Math as CesiumMath, HeadingPitchRange } from "cesium";
 import React, { useMemo } from 'react';
 import { Tree } from '@itwin/itwinui-react/bricks';
+
 import { parseTileset, LevelOfDetail } from '../tilesetParser';
 
-import { Matrix4, Model, Math as CesiumMath, HeadingPitchRange } from "cesium";
-
-
 const tilesetPath = './cesiumStatic/data/SanFran_Street_level_Ferry_building/tileset.json';
-const tilesetData = await parseTileset(tilesetPath, []);
+const tilesetData: LevelOfDetail[] = await parseTileset(tilesetPath, []);
+
 for (let i = 0; i < tilesetData.length; i++) {
   if (!tilesetData[i]) {
     tilesetData[i] = { tiles: [], expanded: false, selected: false, level: i };
   }
 }
-// console.log(tilesetData);
 
 let Sidebar = (cesiumViewer) => {
   const [data, setData] = React.useState(tilesetData);
-
-  console.log("Sidebar cesiumViewer ", cesiumViewer)
 
   return (
     <div className='sidebar'>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -92,66 +92,68 @@ let Sidebar = (cesiumViewer) => {
 
   return (
     <div className='sidebar'>
-      <div style={{ display: 'flex', gap: 6, alignItems: 'center', padding: '12px' }}>
-        <Label>Tileset URL</Label>
-        <TextBox.Root>
-          <TextBox.Input id={'tilesetUrlInput'} />
-        </TextBox.Root>
-        <Button
-					onClick={async (e) => {
-            console.log('Load tileset button clicked');
-            const url = (document.getElementById('tilesetUrlInput') as HTMLInputElement).value;
-            if (!url) {
-              console.log('No url provided');
-              return;
-            }
-            console.log('Loading from url', url);
-
-            let absoluteUrl: string;
-            if (url.indexOf('://') > 0 || url.indexOf('//') === 0) {
-              absoluteUrl = url;
-            } else {
-              absoluteUrl = new URL(url, window.location.href).href;
-            }
-
-            // No need to reload tileset if URL is the same
-            if (absoluteUrl === tilesetUrl) {
-              console.log('Url is the same, not reloading tileset');
-              return;
-            }
-            setTilesetUrl(absoluteUrl);
-
-            let tilesetData: LevelOfDetail[] = [];
-            if (absoluteUrl) {
-              try {
-                tilesetData = await parseTileset(absoluteUrl, [], [], 0);
-                // Load tileset to get transform
-                await loadEntireTileset(absoluteUrl);
-              } catch (error) {
-                console.error('Error parsing tileset:', error);
+      <div style={{ height: '140px' }}>
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center', padding: '12px' }}>
+          <Label>Tileset URL</Label>
+          <TextBox.Root>
+            <TextBox.Input id={'tilesetUrlInput'} />
+          </TextBox.Root>
+          <Button
+            onClick={async (e) => {
+              console.log('Load tileset button clicked');
+              const url = (document.getElementById('tilesetUrlInput') as HTMLInputElement).value;
+              if (!url) {
+                console.log('No url provided');
                 return;
               }
-              
-              setData(tilesetData);
-            }
-            console.log('Lods:', tilesetData);
-					}}
-				>
-					Load
-				</Button>
-      </div>
-      <div style={{ display: 'flex', gap: 6, alignItems: 'center', padding: '12px' }}>
-        <Button onClick={handleLoadEntireTileset} disabled={entireTilesetLoaded}>
-          {entireTilesetLoaded ? 'Entire tileset loaded' : 'Load entire tileset'}
-        </Button>
-        <div className='status-icon' style={entireTilesetLoaded ? {display: 'block'} : { display: 'none' }}>
-          <SvgStatusSuccess />
+              console.log('Loading from url', url);
+
+              let absoluteUrl: string;
+              if (url.indexOf('://') > 0 || url.indexOf('//') === 0) {
+                absoluteUrl = url;
+              } else {
+                absoluteUrl = new URL(url, window.location.href).href;
+              }
+
+              // No need to reload tileset if URL is the same
+              if (absoluteUrl === tilesetUrl) {
+                console.log('Url is the same, not reloading tileset');
+                return;
+              }
+              setTilesetUrl(absoluteUrl);
+
+              let tilesetData: LevelOfDetail[] = [];
+              if (absoluteUrl) {
+                try {
+                  tilesetData = await parseTileset(absoluteUrl, [], [], 0);
+                  // Load tileset to get transform
+                  await loadEntireTileset(absoluteUrl);
+                } catch (error) {
+                  console.error('Error parsing tileset:', error);
+                  return;
+                }
+                
+                setData(tilesetData);
+              }
+              console.log('Lods:', tilesetData);
+            }}
+          >
+            Load
+          </Button>
         </div>
-      </div>
-      <Text variant='body-sm' style={{ padding: '12px' }}>
-        Or select a level of detail or tile to view:
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center', padding: '12px' }}>
+          <Button onClick={handleLoadEntireTileset} disabled={entireTilesetLoaded}>
+            {entireTilesetLoaded ? 'Entire tileset loaded' : 'Load entire tileset'}
+          </Button>
+          <div className='status-icon' style={entireTilesetLoaded ? {display: 'block'} : { display: 'none' }}>
+            <SvgStatusSuccess />
+          </div>
+        </div>
+        <Text variant='body-sm' style={{ padding: '12px' }}>
+          Or select a level of detail or tile to view:
         </Text>
-      <Tree.Root className='lod-tree' style={{ backgroundColor: 'var(--ids-color-bg-neutral-base)' }}>
+      </div>
+      <Tree.Root style={{ backgroundColor: 'var(--ids-color-bg-neutral-base)', height: 'calc(100vh - 140px)' }}>
         {data.map((item, index, items) => {
           const handleSelection = async () => {
             console.log('handleSelection', item);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,36 +1,119 @@
-import { Matrix4, Model, Math as CesiumMath, HeadingPitchRange } from "cesium";
-import React, { useMemo } from 'react';
+import { Matrix4, Model, Math as CesiumMath, HeadingPitchRange, Cesium3DTileset, Cesium3DTile, TileAvailability } from 'cesium';
+import React, { useEffect, useMemo } from 'react';
 import { Tree } from '@itwin/itwinui-react/bricks';
-
 import { parseTileset, LevelOfDetail } from '../tilesetParser';
 
 const tilesetPath = './cesiumStatic/data/SanFran_Street_level_Ferry_building/tileset.json';
-const tilesetData: LevelOfDetail[] = await parseTileset(tilesetPath, []);
+let tilesetLoaded = false;
 
-for (let i = 0; i < tilesetData.length; i++) {
-  if (!tilesetData[i]) {
-    tilesetData[i] = { tiles: [], expanded: false, selected: false, level: i };
-  }
-}
+// const tilesetData: LevelOfDetail[] = await parseTileset(tilesetPath, []);
+// for (let i = 0; i < tilesetData.length; i++) {
+//   if (!tilesetData[i]) {
+//     tilesetData[i] = { tiles: [], expanded: false, selected: false, level: i };
+//   }
+// }
 
 let Sidebar = (cesiumViewer) => {
-  const [data, setData] = React.useState(tilesetData);
+  const [data, setData] = React.useState<LevelOfDetail[]>([]);
+
+  useEffect(() => {
+    (async function() {
+      const { viewer } = cesiumViewer;
+      if (!viewer?.scene) {
+        return;
+      }
+      console.log("viewer", viewer)
+
+      const lods: LevelOfDetail[] = [];
+
+      const tileset = await Cesium3DTileset.fromUrl(tilesetPath);
+      tileset.skipLevelOfDetail = false;
+      tileset.maximumScreenSpaceError = 0;
+      tileset.preloadWhenHidden = true;
+      tileset.show = false;
+      tileset.maximumCacheOverflowBytes = 536870912 * 10;
+      console.log("tileset", tileset);
+
+      viewer.scene.primitives.add(tileset);
+      viewer.zoomTo(tileset);
+
+      function trackTile(tile: any) {
+        const level = parseInt(tile._depth);
+        const index = level - 1;
+        const uri = tile.content.url.split('/').slice(-2).join('/');
+        if (lods[index]) {
+          lods[index].tiles.push({
+            uri: uri,
+            selected: false,
+          });
+        } else {
+          lods[index] = {
+            level: level,
+            expanded: false,
+            selected: false,
+            tiles: [
+              {
+                uri: uri,
+                selected: false,
+              },
+            ],
+          };
+        }
+      }
+      tileset.tileLoad.addEventListener(trackTile);
+
+      tileset.allTilesLoaded.addEventListener(() => {
+        if (!tilesetLoaded) {
+          tileset.tileLoad.removeEventListener(trackTile);
+          console.log("all tiles loaded", lods);
+          setData(lods);
+          tilesetLoaded = true;
+        }
+
+        // Weird issue where the tiles recorded with trackTile are not the same as
+        // the tiles parsed in tilesetData - trackTile is missing some
+
+        // console.log("comparing with parsed data...");
+        // for (let i = 1; i < lods.length; i++) {
+        //   if (lods[i + 2] && lods[i + 2].tiles.length !== tilesetData[i].tiles.length) {
+        //     console.log("parsed tileset data and event tileset data do not match at level", i);
+
+        //     if (i < 4) {
+        //       for (let j = 0; j < tilesetData[i].tiles.length; j++) {
+        //         const tile = tilesetData[i].tiles[j];
+        //         const found = lods[i + 2].tiles.find((t) => {
+        //           const tileUri = t.uri.split('/').slice(-2).join('/');
+        //           return tileUri === tile.uri;
+        //         });
+        //         if (!found) {
+        //           console.log("missing tile", tile.uri, "at level", i);
+        //         }
+        //       }
+        //     }
+        //   }
+        // }
+      });
+    })()
+  }, [cesiumViewer]);
 
   return (
     <div className='sidebar'>
     <Tree.Root>
       {data.map((item, index, items) => {
         const handleSelection = async () => {
-          console.log("tiles ", item.tiles)
+          console.log("tiles", item.tiles);
+
           const gltfPos = [0.8443837640659682, -0.5357387973460459, 0.0, 0.0, 0.32832660036003297, 0.5174791372742712, 0.7902005985709575, 0.0, -0.42334111834053034, -0.667232555788526, 0.6128482797708588, 0.0, -2703514.1639288412, -4261038.79165873, 3887533.1514879903, 1.0];
           let transformToRoot = Matrix4.unpack(gltfPos);
           const prefix = "./cesiumStatic/data/SanFran_Street_level_Ferry_building/";
-          const tNames = item.tiles.map(x => x.uri)
-          const {viewer} = cesiumViewer;
-          console.log("viewer ", viewer)
+          const tNames = item.tiles.map(x => x.uri);
+          const { viewer } = cesiumViewer;
+          // Clear previous models
+          viewer.scene.primitives.removeAll();
+
           let model;
           for (const tU of tNames) {
-            const modelURL = prefix.concat(tU)
+            const modelURL = prefix.concat(tU);
             try {
               model = viewer.scene.primitives.add(
                 await Model.fromGltfAsync({
@@ -39,11 +122,12 @@ let Sidebar = (cesiumViewer) => {
                 }),
               );
             } catch (error) {
-              console.log("error ", error)
+              console.log("error ", error);
             }
           }
+
           model.readyEvent.addEventListener(() => {
-            console.log("model ", model  );
+            console.log("model", model);
             const camera = viewer.camera;
 
             // Zoom to model
@@ -124,7 +208,7 @@ let Sidebar = (cesiumViewer) => {
                 aria-setsize={children.length}
                 label={child.uri}
                 selected={child.selected}
-                onSelectedChange={handleSelection}
+                // onSelectedChange={handleSelection}
               />
             })}
           </React.Fragment>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -115,7 +115,7 @@ let Sidebar = (cesiumViewer) => {
 
   return (
     <div className='sidebar'>
-    <Tree.Root style={{ backgroundColor: 'var(--ids-color-bg-neutral-base)' }}>
+    <Tree.Root className='lod-tree' style={{ backgroundColor: 'var(--ids-color-bg-neutral-base)' }}>
       {data.map((item, index, items) => {
         const handleSelection = async () => {
           console.log("handleSelection", item);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -46,13 +46,13 @@ let Sidebar = (cesiumViewer) => {
   }
 
   /**
-   * Called when the "Load entire tileset" button is clicked
+   * Called when the 'Load entire tileset' button is clicked
    */
   async function handleLoadEntireTileset() {
     if (tilesetUrl) {
       await loadEntireTileset(tilesetUrl);
     } else {
-      console.log("No tileset URL provided");
+      console.log('No tileset URL provided');
     }
   }
 
@@ -63,7 +63,7 @@ let Sidebar = (cesiumViewer) => {
    * individual glTF models when they are loaded.
    */
   async function loadEntireTileset(url: string) {
-    console.log("Loading entire tileset");
+    console.log('Loading entire tileset');
 
     if (selectedLodIndices && selectedLodIndices[0] === -1) {
       console.log('Entire tileset already loaded');
@@ -108,7 +108,7 @@ let Sidebar = (cesiumViewer) => {
             console.log('Loading from url', url);
 
             let absoluteUrl: string;
-            if (url.indexOf("://") > 0 || url.indexOf("//") === 0) {
+            if (url.indexOf('://') > 0 || url.indexOf('//') === 0) {
               absoluteUrl = url;
             } else {
               absoluteUrl = new URL(url, window.location.href).href;
@@ -116,7 +116,7 @@ let Sidebar = (cesiumViewer) => {
 
             // No need to reload tileset if URL is the same
             if (absoluteUrl === tilesetUrl) {
-              console.log("Url is the same, not reloading tileset");
+              console.log('Url is the same, not reloading tileset');
               return;
             }
             setTilesetUrl(absoluteUrl);
@@ -128,13 +128,13 @@ let Sidebar = (cesiumViewer) => {
                 // Load tileset to get transform
                 await loadEntireTileset(absoluteUrl);
               } catch (error) {
-                console.error("Error parsing tileset:", error);
+                console.error('Error parsing tileset:', error);
                 return;
               }
               
               setData(tilesetData);
             }
-            console.log("Lods:", tilesetData);
+            console.log('Lods:', tilesetData);
 					}}
 				>
 					Load
@@ -142,7 +142,7 @@ let Sidebar = (cesiumViewer) => {
       </div>
       <div style={{ display: 'flex', gap: 6, alignItems: 'center', padding: '12px' }}>
         <Button onClick={handleLoadEntireTileset} disabled={entireTilesetLoaded}>
-          {entireTilesetLoaded ? "Entire tileset loaded" : "Load entire tileset"}
+          {entireTilesetLoaded ? 'Entire tileset loaded' : 'Load entire tileset'}
         </Button>
         <div className='status-icon' style={entireTilesetLoaded ? {display: 'block'} : { display: 'none' }}>
           <SvgStatusSuccess />
@@ -154,7 +154,7 @@ let Sidebar = (cesiumViewer) => {
       <Tree.Root className='lod-tree' style={{ backgroundColor: 'var(--ids-color-bg-neutral-base)' }}>
         {data.map((item, index, items) => {
           const handleSelection = async () => {
-            console.log("handleSelection", item);
+            console.log('handleSelection', item);
             
             if (!item.expanded) {
               handleExpanded();
@@ -184,7 +184,7 @@ let Sidebar = (cesiumViewer) => {
                   }),
                 );
               } catch (error) {
-                console.log("error", error);
+                console.log('error', error);
               }
             }
 
@@ -248,13 +248,13 @@ let Sidebar = (cesiumViewer) => {
                       zoomToModel(model, viewer);
                     })
                   } catch (error) {
-                    console.log("error", error)
+                    console.log('error', error)
                   }
                 };
 
                 const tooltipContent = `Filename: ${child.uri}\nGeometric error: ${child.geometricError}`;
 
-                return <Tooltip content={tooltipContent} style={{ wordBreak: "break-word", maxWidth: "500px", whiteSpace: "pre-wrap" }} key={child.uri}>
+                return <Tooltip content={tooltipContent} style={{ wordBreak: 'break-word', maxWidth: '500px', whiteSpace: 'pre-wrap' }} key={child.uri}>
                     <Tree.Item
                       key={child.uri}
                       aria-level={2}

--- a/src/components/outer.jsx
+++ b/src/components/outer.jsx
@@ -10,7 +10,7 @@ function Outer() {
       <Sidebar viewer={cesiumViewer} />
       <CesiumMap viewer={cesiumViewer} setCesiumViewer={setCesiumViewer} />
     </>
-  )
+  );
 }
 
 export default Outer;

--- a/src/components/outer.jsx
+++ b/src/components/outer.jsx
@@ -4,17 +4,15 @@ import Header from './Header';
 import React, { useState } from 'react';
 
 function Outer() {
-
   const [cesiumViewer, setCesiumViewer] = useState();
   
-
   return (
     <>
-        <Sidebar viewer={cesiumViewer}/>
-        <Header/>
-        <CesiumMap viewer={cesiumViewer} setCesiumViewer={setCesiumViewer} />
+      <Sidebar viewer={cesiumViewer} />
+      <Header />
+      <CesiumMap viewer={cesiumViewer} setCesiumViewer={setCesiumViewer} />
     </>
   )
 }
 
-export default Outer
+export default Outer;

--- a/src/components/outer.jsx
+++ b/src/components/outer.jsx
@@ -1,6 +1,5 @@
-import CesiumMap from './CesiumMap'
-import Sidebar from './Sidebar'
-import Header from './Header';
+import CesiumMap from './CesiumMap';
+import Sidebar from './Sidebar';
 import React, { useState } from 'react';
 
 function Outer() {
@@ -9,7 +8,6 @@ function Outer() {
   return (
     <>
       <Sidebar viewer={cesiumViewer} />
-      <Header />
       <CesiumMap viewer={cesiumViewer} setCesiumViewer={setCesiumViewer} />
     </>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -35,8 +35,9 @@
 .sidebar {
   width: 400px;
   height: 100vh;
-  overflow-y: scroll;
-  scrollbar-width: auto;
-  scrollbar-color: auto;
   background-color: var(--ids-color-bg-neutral-base);
+}
+
+.lod-tree {
+  height: 100vh;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -51,4 +51,6 @@
 
 .sidebar {
   margin-top: 47px;
+  height: 100vh;
+  overflow: scroll;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,17 +1,14 @@
 #cesiumContainer {
   position: absolute !important;
   left: 330px;
-  top: 47px;
+  top: 0;
   bottom: 0;
   right: 0;
 }
 
-
-
 #sidebar {
   background-color: #fff;
   position: absolute;
-  top: 47px;
   left: 0;
   bottom: 0;
   margin-left: auto;
@@ -51,7 +48,6 @@
 }
 
 .sidebar {
-  margin-top: 47px;
   height: 100vh;
   overflow: scroll;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,24 +1,9 @@
 #cesiumContainer {
   position: absolute !important;
-  left: 330px;
+  left: 400px;
   top: 0;
   bottom: 0;
   right: 0;
-}
-
-#sidebar {
-  background-color: #fff;
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  margin-left: auto;
-  margin-right: auto;
-  z-index: 1;
-  width: 330px;
-  overflow: none;
-  overflow-y:auto;
-  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 1px 1px rgba(16, 22, 26, 0.2),
-    0 2px 6px rgba(16, 22, 26, 0.2);
 }
 
 .header {
@@ -48,6 +33,10 @@
 }
 
 .sidebar {
+  width: 400px;
   height: 100vh;
-  overflow: scroll;
+  overflow-y: scroll;
+  scrollbar-width: auto;
+  scrollbar-color: auto;
+  background-color: var(--ids-color-bg-neutral-base);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -37,7 +37,3 @@
   height: 100vh;
   background-color: var(--ids-color-bg-neutral-base);
 }
-
-.lod-tree {
-  height: 100vh;
-}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,8 +1,8 @@
 import { createRoot } from 'react-dom/client';
 import './index.css';
 
-import App from './App.jsx'
+import App from './App.jsx';
 
 createRoot(document.getElementById('root')).render(
-    <App />
-)
+  <App />
+);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,5 @@
-import { createRoot } from 'react-dom/client'
-import './index.css'
+import { createRoot } from 'react-dom/client';
+import './index.css';
 
 import App from './App.jsx'
 

--- a/src/tilesetParser.ts
+++ b/src/tilesetParser.ts
@@ -5,57 +5,113 @@ export interface LevelOfDetail {
   tiles: {
     displayName: string,
     uri: string,
-    selected: boolean
+    selected: boolean,
+    geometricError?: number,
   }[]
 }
 
-export async function parseTileset(path: string, lods: LevelOfDetail[]): Promise<LevelOfDetail[]> {
+export async function parseTileset(path: string, lods: LevelOfDetail[], buckets: number[], depth: number): Promise<LevelOfDetail[]> {
   const tilesetJson = await fetch(path).then((response) => response.json());
 
-  return (await parseNode(tilesetJson.root, path, lods));
+  return (await parseNode(tilesetJson.root, path, lods, buckets, depth));
 }
 
-async function parseNode(node: any, path: string, lods: LevelOfDetail[]): Promise<LevelOfDetail[]> {
+async function parseNode(node: any, path: string, lods: LevelOfDetail[], buckets: number[], depth: number): Promise<LevelOfDetail[]> {
+  let newDepth = depth;
   if (node.content) {
+    newDepth = depth + 1;
+
+    // Create buckets (lods) based on first node with content
+    // if (buckets.length === 0) {
+    //   const step = node.geometricError / 4;
+    //   for (let i = 1; i < 4; i++) {
+    //     buckets.push(node.geometricError - step * i);
+    //   }
+    //   // console.log("buckets", buckets);
+    // }
+
+    // console.log(node.content.uri, "test depth:", depth);
+
     if (node.content.uri.endsWith('.json')) {
       // If node is another tileset.json, parse it
       const url = new URL(path, window.location.href);
       const prefix = url.pathname.split('/').slice(0, -1).join('/');
       const newPath = `${prefix}/${node.content.uri}`;
-      await parseTileset(newPath, lods);
+      await parseTileset(newPath, lods, buckets, newDepth);
     } else {
       // Otherwise, add the tile to the lods array for the UI tree
-      const level = node.content.uri.split('/')[0];
+      
+      const url = new URL(path, window.location.href);
+      const prefix = url.pathname.split('/').slice(0, -1).join('/');
+      const newPath = `${prefix}/${node.content.uri}`;
+
+      const tile = {
+        displayName: node.content.uri,
+        uri: newPath,
+        selected: false,
+        geometricError: node.geometricError,
+      }
+      let index;
+
+      // Determine level based on buckets, which are based on geometric error
+      // if (node.geometricError > buckets[0]) {
+      //   index = 0;
+      // } else if (node.geometricError > buckets[1]) {
+      //   index = 1;
+      // } else if (node.geometricError > buckets[2]) {
+      //   index = 2;
+      // } else {
+      //   index = 3;
+      // }
+
+      // // Add to actual LODs for UI
+      // if (lods[index]) {
+      //   lods[index].tiles.push(tile);
+      // } else {
+      //   lods[index] = {
+      //     level: index,
+      //     expanded: false,
+      //     selected: false,
+      //     tiles: [tile],
+      //   };
+      // }
+
+      // Old "level" based method
+      // const level = parseInt(node.content.uri.split('/')[0]);
+
+      // Test - use recursive depth as level
+      const level = newDepth;
 
       if (lods[level]) {
-        lods[level].tiles.push({
-          displayName: node.content.uri,
-          uri: node.content.uri,
-          selected: false,
-        });
+        lods[level].tiles.push(tile);
       } else {
         lods[level] = {
-          level: parseInt(level),
+          level: level,
           expanded: false,
           selected: false,
-          tiles: [
-            {
-              displayName: node.content.uri,
-              uri: node.content.uri,
-              selected: false,
-            },
-          ],
+          tiles: [ tile ],
         };
       }
-
     }
   }
 
   if (node.children) {
     for (const child of node.children) {
-      await parseNode(child, path, lods);
+      await parseNode(child, path, lods, buckets, newDepth);
     }
   }
 
-  return lods;
+  // return lods;
+
+  // return lods.filter((lod) => lod.tiles.length > 0).map((lod, index) => {
+  //   return {
+  //     level: index,
+  //     expanded: lod.expanded,
+  //     selected: lod.selected,
+  //     tiles: lod.tiles
+  //   };
+  // });
+
+  // Remove empty lods
+  return lods.filter((lod) => lod.tiles.length > 0);
 }

--- a/src/tilesetParser.ts
+++ b/src/tilesetParser.ts
@@ -12,78 +12,41 @@ export interface Tile {
   geometricError?: number,
 }
 
-export async function parseTileset(path: string, lods: LevelOfDetail[], buckets: number[], depth: number): Promise<LevelOfDetail[]> {
-  const tilesetJson = await fetch(path).then((response) => response.json());
+export async function parseTileset(tilesetPath: string, lods: LevelOfDetail[], buckets: number[], depth: number): Promise<LevelOfDetail[]> {
+  const response = await fetch(tilesetPath);
+  const tilesetJson = await response.json();
 
-  return (await parseNode(tilesetJson.root, path, lods, buckets, depth));
+  let absoluteUrl: URL;
+  if (tilesetPath.indexOf("://") > 0 || tilesetPath.indexOf("//") === 0) {
+    absoluteUrl = new URL(tilesetPath);
+  } else {
+    absoluteUrl = new URL(tilesetPath, window.location.href);
+  }
+  const basePath = absoluteUrl.href.split('/').slice(0, -1).join('/') + '/';
+
+  return (await parseNode(tilesetJson.root, basePath, lods, buckets, depth));
 }
 
-async function parseNode(node: any, path: string, lods: LevelOfDetail[], buckets: number[], depth: number): Promise<LevelOfDetail[]> {
+async function parseNode(node: any, basePath: string, lods: LevelOfDetail[], buckets: number[], depth: number): Promise<LevelOfDetail[]> {
   let newDepth = depth;
+
   if (node.content) {
     newDepth = depth + 1;
-
-    // Create buckets (lods) based on first node with content
-    // if (buckets.length === 0) {
-    //   const step = node.geometricError / 4;
-    //   for (let i = 1; i < 4; i++) {
-    //     buckets.push(node.geometricError - step * i);
-    //   }
-    //   // console.log("buckets", buckets);
-    // }
-
-    // console.log(node.content.uri, "test depth:", depth);
+    const tilePath = (new URL(node.content.uri, basePath)).href;
 
     if (node.content.uri.endsWith('.json')) {
       // If node is another tileset.json, parse it
-      const url = new URL(path, window.location.href);
-      const prefix = url.pathname.split('/').slice(0, -1).join('/');
-      const newPath = `${prefix}/${node.content.uri}`;
-      await parseTileset(newPath, lods, buckets, newDepth);
+      await parseTileset(tilePath, lods, buckets, newDepth);
     } else {
       // Otherwise, add the tile to the lods array for the UI tree
-      
-      const url = new URL(path, window.location.href);
-      const prefix = url.pathname.split('/').slice(0, -1).join('/');
-      const newPath = `${prefix}/${node.content.uri}`;
-
       const tile = {
         displayName: node.content.uri,
-        uri: newPath,
+        uri: tilePath,
         selected: false,
         geometricError: node.geometricError,
       }
-      let index;
 
-      // Determine level based on buckets, which are based on geometric error
-      // if (node.geometricError > buckets[0]) {
-      //   index = 0;
-      // } else if (node.geometricError > buckets[1]) {
-      //   index = 1;
-      // } else if (node.geometricError > buckets[2]) {
-      //   index = 2;
-      // } else {
-      //   index = 3;
-      // }
-
-      // // Add to actual LODs for UI
-      // if (lods[index]) {
-      //   lods[index].tiles.push(tile);
-      // } else {
-      //   lods[index] = {
-      //     level: index,
-      //     expanded: false,
-      //     selected: false,
-      //     tiles: [tile],
-      //   };
-      // }
-
-      // Old "level" based method
-      // const level = parseInt(node.content.uri.split('/')[0]);
-
-      // Test - use recursive depth as level
       const level = newDepth;
-
       if (lods[level]) {
         lods[level].tiles.push(tile);
       } else {
@@ -99,20 +62,9 @@ async function parseNode(node: any, path: string, lods: LevelOfDetail[], buckets
 
   if (node.children) {
     for (const child of node.children) {
-      await parseNode(child, path, lods, buckets, newDepth);
+      await parseNode(child, basePath, lods, buckets, newDepth);
     }
   }
-
-  // return lods;
-
-  // return lods.filter((lod) => lod.tiles.length > 0).map((lod, index) => {
-  //   return {
-  //     level: index,
-  //     expanded: lod.expanded,
-  //     selected: lod.selected,
-  //     tiles: lod.tiles
-  //   };
-  // });
 
   // Remove empty lods
   return lods.filter((lod) => lod.tiles.length > 0);

--- a/src/tilesetParser.ts
+++ b/src/tilesetParser.ts
@@ -2,12 +2,14 @@ export interface LevelOfDetail {
   level: number,
   expanded: boolean,
   selected: boolean,
-  tiles: {
-    displayName: string,
-    uri: string,
-    selected: boolean,
-    geometricError?: number,
-  }[]
+  tiles: Tile[]
+}
+
+export interface Tile {
+  displayName: string,
+  uri: string,
+  selected: boolean,
+  geometricError?: number,
 }
 
 export async function parseTileset(path: string, lods: LevelOfDetail[], buckets: number[], depth: number): Promise<LevelOfDetail[]> {

--- a/src/tilesetParser.ts
+++ b/src/tilesetParser.ts
@@ -33,18 +33,18 @@ async function parseNode(node: any, lods: LevelOfDetail[]): Promise<LevelOfDetai
       // Read that tileset
       const path = `cesiumStatic/data/SanFran_Street_level_Ferry_building/${child.content.uri}`;
       lods = await parseTileset(path, lods);
-    }
-
-    const uri = child.content.uri;
-    const index = Number(uri.split('/')[0]);
-
-    if (!lods[index]) {
-      lods[index] = { tiles: [], expanded: true, selected: false, level: index };
-    }
-    lods[index].tiles.push({ uri, selected: false});
-
-    if (child.children && child.children.length > 0) {
-      parseNode(child, lods);
+    } else {
+      const uri = child.content.uri;
+      const index = Number(uri.split('/')[0]);
+  
+      if (!lods[index]) {
+        lods[index] = { tiles: [], expanded: true, selected: false, level: index };
+      }
+      lods[index].tiles.push({ uri, selected: false});
+  
+      if (child.children && child.children.length > 0) {
+        lods = await parseNode(child, lods);
+      }
     }
   }
   return lods;

--- a/src/tilesetParser.ts
+++ b/src/tilesetParser.ts
@@ -3,6 +3,7 @@ export interface LevelOfDetail {
   expanded: boolean,
   selected: boolean,
   tiles: {
+    displayName: string,
     uri: string,
     selected: boolean
   }[]
@@ -28,6 +29,7 @@ async function parseNode(node: any, path: string, lods: LevelOfDetail[]): Promis
 
       if (lods[level]) {
         lods[level].tiles.push({
+          displayName: node.content.uri,
           uri: node.content.uri,
           selected: false,
         });
@@ -38,6 +40,7 @@ async function parseNode(node: any, path: string, lods: LevelOfDetail[]): Promis
           selected: false,
           tiles: [
             {
+              displayName: node.content.uri,
               uri: node.content.uri,
               selected: false,
             },

--- a/src/tilesetParser.ts
+++ b/src/tilesetParser.ts
@@ -17,7 +17,7 @@ export async function parseTileset(tilesetPath: string, lods: LevelOfDetail[], b
   const tilesetJson = await response.json();
 
   let absoluteUrl: URL;
-  if (tilesetPath.indexOf("://") > 0 || tilesetPath.indexOf("//") === 0) {
+  if (tilesetPath.indexOf('://') > 0 || tilesetPath.indexOf('//') === 0) {
     absoluteUrl = new URL(tilesetPath);
   } else {
     absoluteUrl = new URL(tilesetPath, window.location.href);

--- a/src/tilesetParser.ts
+++ b/src/tilesetParser.ts
@@ -11,41 +11,46 @@ export interface LevelOfDetail {
 export async function parseTileset(path: string, lods: LevelOfDetail[]): Promise<LevelOfDetail[]> {
   const tilesetJson = await fetch(path).then((response) => response.json());
 
-  for (const child of tilesetJson.root.children) {
-    if (child.content.uri.endsWith('.json')) {
-      // Read that tileset
-      const path = `cesiumStatic/SanFran_Street_level_Ferry_building/${child.content.uri}`;
-      lods = await parseTileset(path, lods);
-    } else {
-      if (child.children && child.children.length > 0) {
-        lods = await parseNode(child, lods);
-      }
-    }
-  }
-
-  // console.log(lods);
-  return lods;
+  return (await parseNode(tilesetJson.root, lods));
 }
 
 async function parseNode(node: any, lods: LevelOfDetail[]): Promise<LevelOfDetail[]> {
-  for (const child of node.children) {
-    if (child.content.uri.endsWith('.json')) {
-      // Read that tileset
-      const path = `cesiumStatic/data/SanFran_Street_level_Ferry_building/${child.content.uri}`;
-      lods = await parseTileset(path, lods);
+  if (node.content) {
+    if (node.content.uri.endsWith('.json')) {
+      // If node is another tileset.json, parse it
+      const path = `cesiumStatic/data/SanFran_Street_level_Ferry_building/${node.content.uri}`;
+      await parseTileset(path, lods);
     } else {
-      const uri = child.content.uri;
-      const index = Number(uri.split('/')[0]);
-  
-      if (!lods[index]) {
-        lods[index] = { tiles: [], expanded: true, selected: false, level: index };
+      // Otherwise, add the tile to the lods array for the UI tree
+      const level = node.content.uri.split('/')[0];
+
+      if (lods[level]) {
+        lods[level].tiles.push({
+          uri: node.content.uri,
+          selected: false,
+        });
+      } else {
+        lods[level] = {
+          level: parseInt(level),
+          expanded: false,
+          selected: false,
+          tiles: [
+            {
+              uri: node.content.uri,
+              selected: false,
+            },
+          ],
+        };
       }
-      lods[index].tiles.push({ uri, selected: false});
-  
-      if (child.children && child.children.length > 0) {
-        lods = await parseNode(child, lods);
-      }
+
     }
   }
+
+  if (node.children) {
+    for (const child of node.children) {
+      await parseNode(child, lods);
+    }
+  }
+
   return lods;
 }

--- a/src/tilesetParser.ts
+++ b/src/tilesetParser.ts
@@ -22,6 +22,8 @@ export async function parseTileset(tilesetPath: string, lods: LevelOfDetail[], b
   } else {
     absoluteUrl = new URL(tilesetPath, window.location.href);
   }
+  // Remove tileset.json from the URL to get the base path
+  // TODO preserve query string, e.g. for SAS URLs from the mesh export API
   const basePath = absoluteUrl.href.split('/').slice(0, -1).join('/') + '/';
 
   return (await parseNode(tilesetJson.root, basePath, lods, buckets, depth));

--- a/src/tilesetParser.ts
+++ b/src/tilesetParser.ts
@@ -11,15 +11,17 @@ export interface LevelOfDetail {
 export async function parseTileset(path: string, lods: LevelOfDetail[]): Promise<LevelOfDetail[]> {
   const tilesetJson = await fetch(path).then((response) => response.json());
 
-  return (await parseNode(tilesetJson.root, lods));
+  return (await parseNode(tilesetJson.root, path, lods));
 }
 
-async function parseNode(node: any, lods: LevelOfDetail[]): Promise<LevelOfDetail[]> {
+async function parseNode(node: any, path: string, lods: LevelOfDetail[]): Promise<LevelOfDetail[]> {
   if (node.content) {
     if (node.content.uri.endsWith('.json')) {
       // If node is another tileset.json, parse it
-      const path = `cesiumStatic/data/SanFran_Street_level_Ferry_building/${node.content.uri}`;
-      await parseTileset(path, lods);
+      const url = new URL(path, window.location.href);
+      const prefix = url.pathname.split('/').slice(0, -1).join('/');
+      const newPath = `${prefix}/${node.content.uri}`;
+      await parseTileset(newPath, lods);
     } else {
       // Otherwise, add the tile to the lods array for the UI tree
       const level = node.content.uri.split('/')[0];
@@ -48,7 +50,7 @@ async function parseNode(node: any, lods: LevelOfDetail[]): Promise<LevelOfDetai
 
   if (node.children) {
     for (const child of node.children) {
-      await parseNode(child, lods);
+      await parseNode(child, path, lods);
     }
   }
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,12 +1,12 @@
-import react from '@vitejs/plugin-react'
+import react from '@vitejs/plugin-react';
 
-import { defineConfig } from "vite";
-import { viteStaticCopy } from "vite-plugin-static-copy";
+import { defineConfig } from 'vite';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
 
-const cesiumSource = "node_modules/cesium/Build/Cesium";
+const cesiumSource = 'node_modules/cesium/Build/Cesium';
 // This is the base url for static files that CesiumJS needs to load.
 // Set to an empty string to place the files at the site's root path
-const cesiumBaseUrl = "cesiumStatic";
+const cesiumBaseUrl = 'cesiumStatic';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -27,7 +27,7 @@ export default defineConfig({
         { src: `${cesiumSource}/Assets`, dest: cesiumBaseUrl },
         { src: `${cesiumSource}/Widgets`, dest: cesiumBaseUrl },
         // Also copy test tileset data
-        { src: `data`, dest: cesiumBaseUrl },
+        { src: 'data', dest: cesiumBaseUrl },
       ],
     }),
   ],


### PR DESCRIPTION
- Improved method for parsing the tileset.json to create the LOD tree
  - I tried a few different methods to traverse the tileset.json to create the "LOD tree" for the user to select from:
1. Determined the LOD from prefixes in the content uri strings, such as "0/..", "1/..", etc. This only worked with the San Fran tileset, and there's no guarantee a tileset will have that organization and naming of its tiles, so this is not a generalized solution.
2. Loaded the entire tileset in the background with CesiumJS and listened to the `tileLoad` event, and create LODs based on each loaded tile's `_depth` property. This requires too much memory to load the whole tileset at once.
3. I tried to create my own levels of detail based on each tile's geometric error when traversing the tree. This brought up the question of what constitutes a "level of detail" in the first place, as in solutions # 1 and # 2 the LODs are based on *tree depth* of a tile, not its geometric error which is how they are actually selected by the viewer. But this solution became complicated to implement, and I got advice to just stick to tree depth as the metric for the UI, so I abandoned this approach.
4. **Approach I finally went with:** similar to # 2, but I traversed the tileset.json myself instead of using CesiumJS's `tileLoad` event. It has the benefits of being simple by using tree depth and not geometric error, but doesn't use a lot of memory. 

- Added text box for user to input tileset.json URL
  - This works with absolute and relative URLs (e.g. `http://localhost:8080/SanFran_Street_level_Ferry_building/tileset.json`, `./cesiumStatic/data/SanFran_Street_level_Ferry_building/tileset.json`)
  - This does NOT preserve query parameters. For example, it would not work with an Azure Storage tileset URL from the Mesh Export API that is authenticated via SAS in the params

![image](https://github.com/user-attachments/assets/543fbec0-c31c-4738-a272-29d45fcb047a)

- Added button to load the entire tileset normally (with refining, via `Cesium.3DTileset` class)

![image](https://github.com/user-attachments/assets/87fef342-9ee7-447b-a15b-9e3a22b042d5)

![image](https://github.com/user-attachments/assets/9e47e42f-1855-40d8-901a-d5d68a36cb67)

- Geolocation bug fixes
  - I changed the tileset transform/model matrix to be just the tileset.json's root transform, rotated -90 degrees in the Z axis
  - I found this to be *mostly* accurate for geolocating the tiles on the few tilesets I tested with (e.g. San Fran ferry building), but it was found through trial-and-error and not a long term solution
  - For example, here are some bushes and fenceposts pretty close to the right place on the map (requires terrain to be on):

![image](https://github.com/user-attachments/assets/6bf4041e-c8bd-4e19-af33-cf500521dd4a)

- Added tooltips with the full URL of each tile, and its geometric error

![image](https://github.com/user-attachments/assets/32b76aba-6a7f-464b-b8ae-9e623839582e) 

- Appearance improvements
  - Removed header for now, until we implement login or another component that needs to live there
  - LOD or tile are highlighted when selected in the UI tree
 
![image](https://github.com/user-attachments/assets/6c803bfe-f62d-4cb6-a37a-3eef6f74e2a4)

![image](https://github.com/user-attachments/assets/66a308b0-83ed-4987-aec2-6632faed53e5)

- Random code cleanup and style consistency/linter fixes

Full screenshot of the updated UI, with a different test tileset loaded:

![image](https://github.com/user-attachments/assets/a7421bd3-dd67-4c17-bf4c-85329a80242e)
